### PR TITLE
Fix: Fixes for Gemini API Key Placeholder and Import Management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,13 +139,13 @@ const Popup: React.FC = () => {
               <HideApiKey
                 value={apikey || ''}
                 onChange={(e) => setApikey(e.target.value)}
-                placeholder="Enter OpenAI API Key"
+                placeholder={`${['gemini_1.5_pro'].includes(selectedModel as string) ? 'Enter Gemini API key' : 'Enter OpenAI API Key'}`}
                 disabled={!model}
                 required
               />
             </div>
             <Button disabled={isloading} type="submit" className="w-full mt-2">
-              save API Key
+              Save Api Key
             </Button>
           </form>
           {submitMessage ? (

--- a/src/modals/BaseModal.ts
+++ b/src/modals/BaseModal.ts
@@ -2,7 +2,7 @@ import {
   GenerateResponseParamsType,
   GenerateResponseReturnType,
   ModalInterface,
-} from '../interface/ModalInterface'
+} from '@/interface/ModalInterface'
 
 /**
  * Abstract base class for modals that interact with an API.
@@ -10,14 +10,14 @@ import {
  * It implements the interface defined above.
  * It provides a base implementation for the `generateResponse` method.
  * It also defines an abstract method that must be implemented by all subclasses.
- * 
+ *
  * @abstract
  * @extends {ModalInterface}
  */
 export abstract class BaseModal extends ModalInterface {
   /**
    * The API key used for making API calls.
-   * 
+   *
    * @protected
    * @type {string}
    */
@@ -25,7 +25,7 @@ export abstract class BaseModal extends ModalInterface {
 
   /**
    * Initializes the modal with the provided API key.
-   * 
+   *
    * @param {string} apiKey - The API key to be used for API calls.
    */
   init(apiKey: string) {
@@ -34,7 +34,7 @@ export abstract class BaseModal extends ModalInterface {
 
   /**
    * Makes an API call with the provided parameters.
-   * 
+   *
    * @protected
    * @abstract
    * @param {GenerateResponseParamsType} props - The parameters for the API call.
@@ -46,7 +46,7 @@ export abstract class BaseModal extends ModalInterface {
 
   /**
    * Generates a response by making an API call with the provided parameters.
-   * 
+   *
    * @async
    * @param {GenerateResponseParamsType} props - The parameters for the API call.
    * @returns {Promise<GenerateResponseReturnType>} The response from the API call.

--- a/src/modals/modal/GeminiAI_1_5_pro.ts
+++ b/src/modals/modal/GeminiAI_1_5_pro.ts
@@ -1,11 +1,11 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { VALID_MODELS } from '@/constants/valid_modals'
 import {
   GenerateResponseParamsType,
   GenerateResponseReturnType,
   ModalInterface,
-} from '../../interface/ModalInterface'
-import { createGoogleGenerativeAI } from '@ai-sdk/google'
+} from '@/interface/ModalInterface'
 import { generateObjectResponce } from '../utils'
-import { VALID_MODELS } from '@/constants/valid_modals'
 
 export class GeminiAI_1_5_pro implements ModalInterface {
   name = 'gemini_1.5_pro'

--- a/src/modals/modal/OpenAI_3_5_turbo.ts
+++ b/src/modals/modal/OpenAI_3_5_turbo.ts
@@ -1,11 +1,11 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObjectResponce } from '../utils'
+import { VALID_MODELS } from '@/constants/valid_modals'
 import {
   GenerateResponseParamsType,
   GenerateResponseReturnType,
   ModalInterface,
-} from '../../interface/ModalInterface'
-import { createOpenAI } from '@ai-sdk/openai'
-import { generateObjectResponce } from '../utils'
-import { VALID_MODELS } from '@/constants/valid_modals'
+} from '@/interface/ModalInterface'
 
 export class OpenAI_3_5_turbo implements ModalInterface {
   name = 'openai_3.5_turbo'

--- a/src/modals/modal/OpenAI_40.ts
+++ b/src/modals/modal/OpenAI_40.ts
@@ -1,11 +1,11 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObjectResponce } from '../utils'
+import { VALID_MODELS } from '@/constants/valid_modals'
 import {
   GenerateResponseParamsType,
   GenerateResponseReturnType,
   ModalInterface,
-} from '../../interface/ModalInterface'
-import { createOpenAI } from '@ai-sdk/openai'
-import { generateObjectResponce } from '../utils'
-import { VALID_MODELS } from '@/constants/valid_modals'
+} from '@/interface/ModalInterface'
 
 export class OpenAi_4o implements ModalInterface {
   name = 'openai_4o'


### PR DESCRIPTION
- Fix: Manage placeholder "Enter Gemini API key" for API key when gemini_1.5_pro is selected.
- Fix: Manage Imports Properly.